### PR TITLE
Add a conservative max height to cat images

### DIFF
--- a/src/components/Cats.css
+++ b/src/components/Cats.css
@@ -15,6 +15,7 @@
 
 .cats__image img {
   max-width: 100%;
+  max-height:50vh;
 }
 
 .stream-mode-enabled .cats__image img {


### PR DESCRIPTION
The static images are sometimes too tall. I set a fairly conservative max height in my local CSS and it works pretty well so here's a PR adding it to the site.

(this is the best website I've ever seen btw)